### PR TITLE
Add tomcat

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,6 +17,4 @@ mod "tomcat",
 #mod "stdlib",
 #  :git => "git://github.com/puppetlabs/puppetlabs-stdlib.git"
 
-# add tomcat
-include tomcat::debian
 

--- a/dspace-init.pp
+++ b/dspace-init.pp
@@ -71,6 +71,15 @@ postgresql::db { 'dspace':
   password => 'dspace'
 }
 
+# add tomcat
+include tomcat
+
+tomcat::instance {"dspace":
+  ensure    => present,
+  http_port => "8080",
+}
+
+
 # Kickoff a DSpace installation for the 'vagrant' default user
 dspace::install { vagrant-dspace:
    owner   => "vagrant",


### PR DESCRIPTION
This is using the Github version of the camptocamp tomcat puppet module, and merely brings up the default tomcat, which is tomcat 6. Good enough for now. It wants to put webapps in /srv/tomcat/dspace/webapps and it looks like the user is "tomcat" for now, all of which works for me. This is ready for actual DSpace usage, I think, we just have to work out the configuration details.
