### PR TITLE
adding probe.xml.erb context fragment template

### DIFF
--- a/dspace-init.pp
+++ b/dspace-init.pp
@@ -117,9 +117,9 @@ exec {"Download and install the Psi-probe war":
    user      => "vagrant",
    logoutput => true,
 }
-
+ 
 ->
-
+ 
 # Set the runlevels of tomcat7-vagrant
 # AND start the tomcat7-vagrant service
 service {"tomcat7-vagrant":
@@ -127,3 +127,12 @@ service {"tomcat7-vagrant":
    ensure => "running",
 }
 
+->
+
+# add a context fragment file for Psi-probe, and restart tomcat7-vagrant
+file { "/home/vagrant/tomcat/conf/Catalina/localhost/probe.xml" :
+   ensure  => file,
+   owner   => vagrant,
+   group   => vagrant,
+   content => template("dspace/probe.xml.erb"),
+}

--- a/modules/dspace/templates/probe.xml.erb
+++ b/modules/dspace/templates/probe.xml.erb
@@ -1,0 +1,15 @@
+<!--
+
+    Context configuration file for the Psi-Probe Web App
+
+-->
+
+
+<Context docBase="/home/vagrant/tomcat/webapps/probe"
+         privileged="true" antiResourceLocking="false" antiJARLocking="false">
+
+  <!-- Link to the user database we will get roles from -->
+  <ResourceLink name="users" global="UserDatabase"
+                type="org.apache.catalina.UserDatabase"/>
+
+</Context>


### PR DESCRIPTION
re: DS-1668, this context fragment is required to completely move PsiProbe out of the somewhat too volatile ~/dspace/webapps appbase folder.
