### PR TITLE
Give unique name to downloaded box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
     # please see the online documentation at vagrantup.com.
 
     # Every Vagrant virtual environment requires a box to build off of.
-    config.vm.box = "precise64"
+    config.vm.box = "dspace-precise64"
 
     # BEGIN Vagrant-Cachier configuration ####################################
     # check for the presence of the Vagrant-Cachier plugin before attempting


### PR DESCRIPTION
As the default virtualbox from vagrant is called "precise64" and this may be likely to be already present in your environment the installation and provisioning will fail due to unresolved dependencies.
The dependencies are only met in the virtualbox file you provide in config.vm.box_url, so you have to assure that this one is downloaded and used and not the default precise64 from the vagrant maintainer.
