### PR TITLE
[DS-2450] work with IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,12 @@
 .vagrant/
 
 # Ignore anything in "content/" subfolder, except for "content/README"
-/content/
 !/content/README
+/content/
+
+# Ignore "dspace/" and "dspace-src/" subfolders, except for the READMEs
+!/dspace/README
+/dspace/
+
+!/dspace-src/README
+/dspace-src/

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@
 /content/
 
 # Ignore "dspace/" and "dspace-src/" subfolders, except for the READMEs
-!/dspace/README
+!/dspace/.gitkeep
 /dspace/
 
-!/dspace-src/README
+!/dspace-src/.gitkeep
 /dspace-src/
+
+# ignore IDE folders
+.idea

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -236,4 +236,9 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "dspace-src", "/home/vagrant/dspace-src"
     config.vm.synced_folder "dspace", "/home/vagrant/dspace"
 
+    # if we're running with vagrant-notify, send a notification that we're done, in case we've wandered off
+    if Vagrant.has_plugin?('vagrant-notify')
+        config.vm.provision :shell, :inline => "notify-send --urgency=critical 'Vagrant-DSpace is up! Get back to work! :-)'", run: "always"
+    end
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -226,9 +226,14 @@ Vagrant.configure("2") do |config|
         #vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
 
         # This allows symlinks to be created within the /vagrant root directory,
-        # which is something librarian-puppet needs to be able to do. This might
+        # which is something librarian-puppet needs to be able to do. This mighti
         # be enabled by default depending on what version of VirtualBox is used.
         # Borrowed from https://github.com/purple52/librarian-puppet-vagrant/
         vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
+
+    # set up dspace-src and dspace as synced folders to support the use of an IDE on the host machine
+    config.vm.synced_folder "dspace-src", "/home/vagrant/dspace-src"
+    config.vm.synced_folder "dspace", "/home/vagrant/dspace"
+
 end

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,5 +1,3 @@
-# ignore any .yaml files except common.yaml
+# ignore any files or folders except common.yaml
 !common.yaml
-*.yaml
-local-bootstrap.sh
-dotfiles
+*

--- a/dspace-init.pp
+++ b/dspace-init.pp
@@ -6,6 +6,7 @@
 #
 # Tested on:
 # - Ubuntu 12.04
+# - Ubuntu 14.04.1
 
 # grab Maven version from hiera for later use
 $mvn_version = hiera('mvn_version')

--- a/dspace-src/README
+++ b/dspace-src/README
@@ -1,0 +1,1 @@
+dspace-src folder, made accessible for use with IDEs

--- a/dspace-src/README
+++ b/dspace-src/README
@@ -1,1 +1,0 @@
-dspace-src folder, made accessible for use with IDEs

--- a/dspace/README
+++ b/dspace/README
@@ -1,0 +1,1 @@
+dspace deployment folder, made accessible for use with IDEs

--- a/dspace/README
+++ b/dspace/README
@@ -1,1 +1,0 @@
-dspace deployment folder, made accessible for use with IDEs

--- a/modules/dspace/manifests/install.pp
+++ b/modules/dspace/manifests/install.pp
@@ -98,7 +98,7 @@ define dspace::install ($owner,
 
     # cp tmp_src_dir/* to src_dir/
     exec { "copy ${tmp_src_dir}/* to ${src_dir}/":
-        command   => "cp -r ${tmp_src_dir}/* ${src_dir}/",
+        command   => "cp -r ${tmp_src_dir}/. ${src_dir}/; chown -R ${owner}:${group} ${src_dir}",
         logoutput => true,
 }
 


### PR DESCRIPTION
This is a rather simple addition to Vagrant-DSpace, it exposes both the dspace and dspace-src folders via Virtualbox's synced folders (managed by Vagrant). This allows you to utilize the IDE of your choice on your host machine, and even compile with Maven on your host. The workflow of deploying to the ~/dspace folder is still much easier if you run ant on the command line inside the Virtual Box machine, but there's room for someone to figure out how to make Ant work on the host as well. If you've gotten used to using Vim on the Virtual Box, this PR does not change any paths, you can still work the old way. But if you've been craving running an IDE, or Sublime Text 3, or Geany, or Atom, or some other editor on your host machine, this PR will let you do that.