### PR TITLE
Remove SSH check, and switch to using https for git

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -1,6 +1,6 @@
 ---
 
-git_repo          : 'git@github.com:DSpace/DSpace.git'
+git_repo          : 'https://github.com/DSpace/DSpace.git'
 git_branch        : 'master'
 mvn_version       : '3.0.5'
 mvn_params        : '-Denv=vagrant'

--- a/modules/dspace/manifests/init.pp
+++ b/modules/dspace/manifests/init.pp
@@ -63,10 +63,4 @@ class dspace ($java_version = "7")
     # Install Git
     package { "git":
     }
-
-    # Check if our SSH connection to GitHub works. This verifies that SSH forwarding is working right.
-    #exec { "Verify SSH connection to GitHub works?" :
-    #    command => "ssh -T -oStrictHostKeyChecking=no git@github.com",
-    #    returns => 1,   # If this succeeds, it actually returns '1'. If it fails, it returns '255'
-    #}
 }

--- a/modules/dspace/manifests/init.pp
+++ b/modules/dspace/manifests/init.pp
@@ -65,8 +65,8 @@ class dspace ($java_version = "7")
     }
 
     # Check if our SSH connection to GitHub works. This verifies that SSH forwarding is working right.
-    exec { "Verify SSH connection to GitHub works?" :
-        command => "ssh -T -oStrictHostKeyChecking=no git@github.com",
-        returns => 1,   # If this succeeds, it actually returns '1'. If it fails, it returns '255'
-    }
+    #exec { "Verify SSH connection to GitHub works?" :
+    #    command => "ssh -T -oStrictHostKeyChecking=no git@github.com",
+    #    returns => 1,   # If this succeeds, it actually returns '1'. If it fails, it returns '255'
+    #}
 }

--- a/modules/dspace/manifests/install.pp
+++ b/modules/dspace/manifests/install.pp
@@ -85,7 +85,6 @@ define dspace::install ($owner,
         logoutput => true,
         tries     => 2, # try 2 times, with a ten minute timeout, GitHub is sometimes slow, if it's too slow, might as well get everything else done
         timeout   => 600,
-        require   => [Package["git"], Exec["Verify SSH connection to GitHub works?"]],
     }
 
 ->


### PR DESCRIPTION
I use an SSH key for Github, but somehow this test failed when I tried to install vagrant-dspace. I found that by doing the modification below, it worked perfectly fine. I haven't disabled any ssh-forwarding, so whatever was there should still work, however for people who have problems with ssh forwarding, this still enables them to quickly install vagrant-dspace.