### PR TITLE
Add db_port config to make Postgres on VM available locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ If you look at the `config` folder, there are a few files you'll be interested i
 * `vm_memory` - Specify the amount of memory to give this VM (2GB by default)
 * `vm_cpu_max` - Limit the amount of local CPU this VM can access (off by default)
 * `ip_address` - Local IP address to assign to the VM
-* `port` - Port this VM should use for Tomcat (port 8080 by default)
+* `port` - Local port this VM should use for Tomcat (port 8080 by default)
+* `db_port` - Local port where VM's PostgreSQL database will be accessible (port 5432 by default). This lets you manage the VM database locally via tools like pgAdminIII, and debug code in your local IDE while using the VM database for "test" data.
 * `sync_src_to_host` - Whether or not to auto-sync the `~/dspace-src/` folder on the VM to the `[vagrant-dspace]/dspace-src/` folder on your host machine. By default this is false as the sync folder currently is often slow. But, if you want to work in a local IDE, you probably will want this to be set to "true".
 * `git_repo` - it would be a good idea to point this to your own fork of DSpace. By default this is a GitHub SSH URL. But, if vagrant-dspace is unable to connect to GitHub via SSH, this will be dynamically changed to a GitHub HTTPS URL.
 * `git_branch` - if you're constantly working on another brach than master, you can change it here

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,11 +68,15 @@ Vagrant.configure("2") do |config|
 
     # Create a forwarded port mapping which allows access to a specific port
     # within the machine from a port on the host machine. In the example below,
-    # accessing "localhost:8080" will access port 8080 on the VM.
+    # accessing "localhost:[port]" will access port 8080 on the VM.
     config.vm.network :forwarded_port, guest: 8080, host: CONF['port'],
       auto_correct: true
 
-    # If a port collision occurs (i.e. port 8080 on local machine is in use),
+    # Forward PostgreSQL database port (5432) to local machine port (for DB & pgAdmin3 access)
+    config.vm.network :forwarded_port, guest: 5432, host: CONF['db_port'],
+      auto_correct: true
+
+    # If a port collision occurs (e.g. port 8080 on local machine is in use),
     # then tell Vagrant to use the next available port between 8081 and 8100
     config.vm.usable_port_range = 8081..8100
 
@@ -282,5 +286,5 @@ Vagrant.configure("2") do |config|
     end
 
     # Message to display to user after 'vagrant up' completes
-    config.vm.post_up_message = "Setup of 'vagrant-dspace' is now COMPLETE! DSpace should now be available at:\n\nhttp://localhost:#{CONF['port']}/xmlui/\n\nYou can login using '#{CONF['admin_email']}' with password '#{CONF['admin_passwd']}'.\nYou can also SSH into the new VM via 'vagrant ssh'"
+    config.vm.post_up_message = "Setup of 'vagrant-dspace' is now COMPLETE! DSpace should now be available at:\n\nhttp://localhost:#{CONF['port']}/xmlui/\nLOGIN: '#{CONF['admin_email']}', PASSWORD: '#{CONF['admin_passwd']}'\n\nThe DSpace database is accessible via local port #{CONF['db_port']}.\nYou can SSH into the new VM via 'vagrant ssh'"
 end

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,13 @@ ip_address : 192.168.50.2
 # (Changes to this setting require a 'vagrant reload' to take effect)
 port       : 8080
 
+# Local port which will access PostgreSQL on this VM
+# This allows you to access the VM's DSpace database via pgAdminIII, or even debug code
+# (via a locally installed IDE) while using this database.
+# NOTE: if this port is already in use, Vagrant will use the next available port between 8081 and 8100
+# (Changes to this setting require a 'vagrant reload' to take effect)
+db_port    : 5432
+
 # Whether to sync the ~/dspace-src/ (DSpace Source) to the host machine
 # (under [vagrant-dspace]/dspace-src/).
 #   * Setting to "true" means the local copy & VM copy are always in sync, and
@@ -45,7 +52,7 @@ port       : 8080
 #     WILL take significantly longer (e.g. ~45mins instead of 10-15mins). 
 #     Subsequent 'vagrant up' calls will use existing local source (until deleted).
 #   * Setting to "false" is much more speedy, but you then can ONLY edit code
-#     directly on the VM (i.e. no IDE integration)
+#     directly on the VM (i.e. no direct IDE integration)
 # By default this is "false" to keep things speedy.
 # (Changes to this setting require a 'vagrant destroy && vagrant up' to take effect)
 sync_src_to_host : false

--- a/config/local.yaml.example
+++ b/config/local.yaml.example
@@ -41,12 +41,19 @@ vm_memory  : 2048
 
 # Local IP address which will refer to this VM
 # (Changes to this setting require a 'vagrant reload' to take effect)
-ip_address: 192.168.50.2
+ip_address : 192.168.50.2
 
 # Local port which will access DSpace/Tomcat on this VM
 # NOTE: if this port is already in use, Vagrant will use the next available port between 8081 and 8100
 # (Changes to this setting require a 'vagrant reload' to take effect)
-port: 8080
+port       : 8080
+
+# Local port which will access PostgreSQL on this VM
+# This allows you to access the VM's DSpace database via pgAdminIII, or even debug code
+# (via a locally installed IDE) while using this database.
+# NOTE: if this port is already in use, Vagrant will use the next available port between 8081 and 8100
+# (Changes to this setting require a 'vagrant reload' to take effect)
+db_port    : 5432
 
 # Whether to sync the ~/dspace-src/ (DSpace Source) to the host machine
 # (under [vagrant-dspace]/dspace-src/).


### PR DESCRIPTION
This PR adds a new configuration `db_port` which makes PostgreSQL on the VM available via a local port. Defaults to sharing via the local port 5432, but you can tweak it via your `local.yaml` file.

The `db_port` config is useful for the following use cases:
* You can now install pgAdminIII locally to view/manage your database contents in the VM
* You can now run an IDE locally, and debug code while pointing at the database contents in the VM (So, if your VM has good test data, you can now use that from your local IDE).  To do so, you'd just install an IDE, and tweak your local `build.properties` to point at the `db_port`.

I've been using this locally now for a few weeks to do the latter.  It lets me use my IDE locally, with a separate checkout of DSpace code, but point it at my database in the VM. That means I no longer have Postgres installed on my local machine (I only run it in the VM).
