### PR TITLE
Fixes for DS-2734 and DS-2701

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,13 +6,13 @@ forge "https://forgeapi.puppetlabs.com"
 
 # Install Puppet Labs PostgreSQL module
 # https://github.com/puppetlabs/puppetlabs-postgresql/
-mod "puppetlabs-postgresql", "4.1.0"
+mod "puppetlabs-postgresql", "4.6.0"
 
 # Install Puppet Labs Standard Libraries module
 # https://github.com/puppetlabs/puppetlabs-stdlib
 # (required for puppetlabs-tomcat)
-mod "puppetlabs-stdlib", "4.5.1"
+mod "puppetlabs-stdlib", "4.9.0"
 
 # Install Puppet Labs Tomcat module
 # https://github.com/puppetlabs/puppetlabs-tomcat/
-mod "puppetlabs-tomcat", "1.2.0"
+mod "puppetlabs-tomcat", "1.3.2"

--- a/puppet-bootstrap-ubuntu.sh
+++ b/puppet-bootstrap-ubuntu.sh
@@ -18,7 +18,7 @@ PUPPET_DIR=/etc/puppet/
 REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
 
 # Version of librarian-puppet to install
-LIBRARIAN_PUPPET_VERSION=2.0.1
+LIBRARIAN_PUPPET_VERSION=2.2.1
 
 #--------------------------------------------------------------------
 # NO TUNABLES BELOW THIS POINT

--- a/puppet.conf
+++ b/puppet.conf
@@ -3,14 +3,5 @@ logdir=/var/log/puppet
 vardir=/var/lib/puppet
 ssldir=/var/lib/puppet/ssl
 rundir=/var/run/puppet
-factpath=$vardir/lib/facter
-templatedir=$confdir/templates
 # For vagrant-dspace, we want Puppet to *also* look for modules under /vagrant/modules/
-modulepath=$confdir/modules:/usr/share/puppet/modules:/vagrant/modules
-
-[master]
-# These are needed when the puppetmaster is run by passenger
-# and can safely be removed if webrick is used.
-ssl_client_header = SSL_CLIENT_S_DN
-ssl_client_verify_header = SSL_CLIENT_VERIFY
-
+basemodulepath=$confdir/modules:/usr/share/puppet/modules:/vagrant/modules


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-2734
https://jira.duraspace.org/browse/DS-2701

Includes the following changes:
* Upgrade to latest version of librarian-puppet (fixes DS-2734)
* Upgrade to latest versions of all puppet modules (just good practice)
* Upgrade to installing PostgreSQL 9.4 + pgcrypto extension (for DS-2701 support)
* Minor cleanup of puppet.conf to avoid warnings with current versions of Puppet.

Currently, I've only tested this against the "Services API" branch (https://github.com/DSpace/DSpace/tree/DS-2701-service-api), which will become the new "master" in time for DSpace 6.0.  But, I think it should be backwards compatible with DSpace 5 (needs verification)