### PR TITLE
DS-2701 : Fix vagrant.properties to be compatible with Hibernate

### DIFF
--- a/modules/dspace/templates/vagrant.properties.erb
+++ b/modules/dspace/templates/vagrant.properties.erb
@@ -59,33 +59,39 @@ db.name=postgres
 # Uncomment the appropriate block below for your database.
 # postgres
 db.driver=org.postgresql.Driver
+db.dialect=org.dspace.storage.rdbms.hibernate.postgres.DSpacePostgreSQL82Dialect
 db.url=jdbc:postgresql://localhost:5432/dspace
 db.username=dspace
 db.password=dspace
+db.schema=public
 
 # oracle
 #db.driver= oracle.jdbc.OracleDriver
-#db.url=jdbc:oracle:thin:@localhost:1521:orcl
-#db.username=
-#db.password=
-
-# Schema name - if your database contains multiple schemas, you can avoid problems with
-# retrieving the definitions of duplicate object names by specifying
-# the schema name here that is used for DSpace by uncommenting the following entry
-db.schema = 
+#db.dialect=org.hibernate.dialect.Oracle10gDialect
+#db.url=jdbc:oracle:thin:@//localhost:1521/xe
+#db.username=dspace
+#db.password=dspace
+# The schema in oracle is the usually the user name
+#db.schema=dspace
 
 # Maximum number of DB connections in pool
 db.maxconnections = 30
 
+# Determine the number of statements that can be cached (set to 0 to disable caching)
+db.statementpool.cache = 50
+
+#######
+# DEPRECATED DB Configurations
+# The following db.* configurations are only kept for backwards compatibility with DSpace <=5
+# (i.e. so that vagrant-dspace will still function for DSpace5-based branches).
+# These have all been removed in DSpace 6 as they are replaced with Hibernate configs (see hibernate.cfg.xml)
+#######
 # Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
 db.maxwait = 5000
-
 # Maximum number of idle connections in pool (-1 = unlimited)
 db.maxidle = -1
-
 # Determine if prepared statement should be cached. (default is true)
 db.statementpool = true
-
 # Specify a name for the connection pool (useful if you have multiple applications sharing Tomcat's dbcp)
 # If not specified, defaults to 'dspacepool'
 db.poolname = dspacepool


### PR DESCRIPTION
Followup to PR #36

I just realized that our default 'vagrant.properties' (customized version of build.properties) requires some minor updates to support DS-2701 (new Services API refactor)

This PR does the following
* Add a few new settings required by Hibernate to vagrant.properties
* Keep a few deprecated "db.*" configs which allow us to retain backwards compatibility with DSpace 5 (for now)