### PR TITLE
Increase VM memory along with Java heap and PermGen memory.

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,9 +20,9 @@
 vm_name    : 'dspace-dev'
 
 # How much memory to provide to VirtualBox VM (in MB)
-# Provide 2GB of memory by default
+# Provide 4GB of memory by default
 # (Changes to this setting require a 'vagrant reload' to take effect)
-vm_memory  : 2048
+vm_memory  : 4096
 
 # Maximum amount of host CPU which VirtualBox VM can use (in %)
 # The example below would only let VM use up to 50% of host CPU
@@ -131,5 +131,5 @@ catalina_base     : '/var/lib/tomcat7'
 # Options to pass to Tomcat
 # This IS customizable. Feel free to tweak memory settings, etc.
 # (Changes to this setting require a 'vagrant provision' to take effect)
-catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx1024m -Xms1024m -XX:MaxPermSize=128m -XX:+UseConcMarkSweepGC'
+catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx2048m -Xms1024m -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC'
 


### PR DESCRIPTION
The default memory settings allow neither of the jspui or xmlui webapps to run in my testing (Fedora 23, VirtualBox 5.0.14) with the Tomcat logs showing many OutOfMemory and PermGen errors and the application pages never loading in my browser.

These settings for VM and Tomcat memory are the minimum to ensure that both jspui and xmlui can be run in the same session without seeing memory errors in the logs.