### PR TITLE
local.cfg instead of vagrant.properties

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -102,12 +102,10 @@ dspace::java_version : '7'
 
 # Maven Defaults
 #
-# Always build/compile DSpace using "vagrant.properties"
-# instead of the normal "build.properties" file
 # IF you want to exclude particular webapps from building & installing, you can do so like:
-# mvn_params: '-Denv=vagrant -P!dspace-lni,!dspace-rdf'
+# mvn_params: '-P!dspace-lni,!dspace-rdf'
 # (This setting is only used during a 'vagrant up')
-mvn_params        : '-Denv=vagrant'
+mvn_params        : ''
 
 # Ant Defaults
 # NOTE: if you change 'git_branch' above, you MAY need to modify this 'ant_installer_dir'

--- a/modules/dspace/manifests/install.pp
+++ b/modules/dspace/manifests/install.pp
@@ -17,7 +17,7 @@
 # - $install_dir        => Location where DSpace instance should be installed (defaults to the home directory of $owner at ~/dspace)
 # - $git_repo           => Git repository to pull DSpace source from. Defaults to DSpace/DSpace in GitHub
 # - $git_branch         => Git branch to build DSpace from. Defaults to "master".
-# - $mvn_params         => Any build params passed to Maven. Defaults to "-Denv=vagrant" which tells Maven to use the vagrant.properties file.
+# - $mvn_params         => Any build params passed to Maven. 
 # - $ant_installer_dir  => Full path of directory where the Ant installer is built to (via Maven).
 # - $admin_firstname    => First Name of the created default DSpace Administrator account.
 # - $admin_lastname     => Last Name of the created default DSpace Administrator account.
@@ -108,21 +108,19 @@ define dspace::install ($owner,
 
 ->
 
-   # Create a 'vagrant.properties' file which will be used to build the DSpace installer
-   # (INSTEAD OF the default 'build.properties' file that DSpace normally uses)
-   file { "${src_dir}/vagrant.properties":
+   # Create a 'local.cfg' file which will be used to build the DSpace installer
+   file { "${src_dir}/local.cfg":
      ensure  => file,
      owner   => $owner,
      group   => $group,
      mode    => 0644,
      backup  => ".puppet-bak",  # If replaced, backup old settings to .puppet-bak
-     content => template("dspace/vagrant.properties.erb"),
+     content => template("dspace/local.cfg.erb"),
    }
 
 ->
 
    # Build DSpace installer.
-   # (NOTE: by default, $mvn_params='-Denv=vagrant', which tells Maven to use the vagrant.properties file created above)
    exec { "Build DSpace installer in ${src_dir}":
      command   => "mvn package ${mvn_params}",
      cwd       => "${src_dir}", # Run command from this directory

--- a/modules/dspace/templates/local.cfg.erb
+++ b/modules/dspace/templates/local.cfg.erb
@@ -1,14 +1,4 @@
-# DSpace build.properties
-# This file should be customised to suit your build environment.
-# Note that not all configuration is handled here, only the most common
-# properties that tend to differ between build environments. 
-# For adjusting global settings or more complex settings, edit the relevant config file.
-#
-# IMPORTANT: Do not remove or comment out settings in build.properties
-# When you edit the "build.properties" file (or a custom *.properties file),
-# take care not to remove or comment out any settings. Doing so, may cause
-# your final "dspace.cfg" file to be misconfigured with regards to that
-# particular setting.  Instead, if you wish to remove/disable a particular
+# If you wish to remove/disable a particular
 # setting, just clear out its value.  For example, if you don't want to be
 # notified of new user registrations, ensure the "mail.registration.notify"
 # setting has no value, e.g. "mail.registration.notify="
@@ -22,7 +12,7 @@
 # to install DSpace. NOTE: this value will be copied over to the
 # "dspace.dir" setting in the final "dspace.cfg" file. It can be
 # modified later on in your "dspace.cfg", if needed.
-dspace.install.dir=/home/vagrant/dspace
+dspace.dir=/home/vagrant/dspace
 
 # DSpace host name - should match base URL.  Do not include port number
 dspace.hostname = localhost

--- a/modules/dspace/templates/profile.erb
+++ b/modules/dspace/templates/profile.erb
@@ -27,10 +27,6 @@ export JAVA_HOME="/usr/lib/jvm/default-java"
 #Base path of Maven
 export MAVEN_HOME="/usr/share/maven"
 
-# Initialize Maven Settings to build DSpace using the 'vagrant.properties' file(instead of default 'build.properties' file)
-# This ensures that you can simply run 'mvn package' from the command-line and Maven will default to using 'vagrant.properties'.
-export MAVEN_OPTS="-Denv=vagrant"
-
 # change the prompt to include the git branch name, which is insanely helpful
 # Also change the prompt to include flags to indicate dirty state (*), stash state ($),
 # and indicate the presence of untracked files (%)


### PR DESCRIPTION
few minor changes, so it starts with the newest commons config