### PR TITLE
aggregated stability changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ In the `config` folder, you will also find a file called `local-bootstrap.sh.exa
 
 local-bootstrap.sh is a "shell provisioner" for Vagrant, and our vagrantfile is [configured to run it](https://github.com/DSpace/vagrant-dspace/blob/master/Vagrantfile#L171) if it is present in the config folder. If you have a fork of Vagrant-DSpace for your own repository management, you may add another shell provisioner, to maintain your own workgroup's customs and configurations. You may find an example of this in the [Vagrant-MOspace](https://github.com/umlso/vagrant-mospace/blob/master/config/mospace-bootstrap.sh) repository.
 
+### apt-spy-2-bootstrap.sh - You can override the default apt-spy-2-bootstrap.sh script
+
+The default apt-spy-2-bootstraph.sh script can be copied to the config folder and modified to reflect your preferences. This can potentially speed up provisiong of new machines by allowing you to tweak the apt-spy2 commands to better fit your typical work conditions. We of course recommend using the default, especially if you do not know for sure where your travels may take you next. But, you are free to tinker with this script as you see fit.
+
 ### maven_settings.xml - Tips on tweaking Maven
 
 If you've copied the example `local-bootstrap.sh` file, you may create a `config/dotfiles` folder, and place a file called `maven_settings.xml` in it, that file will be copied to `/home/vagrant/.m2/settings.xml` every time the `local-bootstrap.sh` provisioner is run. This will allow you to further customize your Maven builds. One handy (though somewhat dangerous) thing to add to your `settings.xml` file is the following profile:
@@ -185,8 +189,8 @@ Vagrant Plugin Recommendations
 
 The following Vagrant plugins are not required, but they do make using Vagrant and vagrant-dspace more enjoyable.
 
-* Land Rush: https://github.com/phinze/landrush
 * Vagrant-Cachier: https://github.com/fgrehm/vagrant-cachier
+* Vagrnat-Hostsupdater: https://github.com/cogitatio/vagrant-hostsupdater
 * Vagrant-Proxyconf: https://github.com/tmatilai/vagrant-proxyconf/
 * Vagrant-VBox-Snapshot: https://github.com/dergachev/vagrant-vbox-snapshot/
 * Vagrant-Notify: https://github.com/fgrehm/vagrant-notify

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -262,6 +262,10 @@ Vagrant.configure("2") do |config|
         # Use VBoxManage to provide Virtual Machine with extra memory (default is only 300MB)
         vb.customize ["modifyvm", :id, "--memory", CONF['vm_memory']]
 
+        vb.memory = CONF['vm_memory']
+        vb.cpus = CONF['vb_cpus'] 
+
+
         if CONF['vb_max_cpu']
           # Use VBoxManage to ensure Virtual Machine only has access to a percentage of host CPU
           vb.customize ["modifyvm", :id, "--cpuexecutioncap", CONF['vm_max_cpu']]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -188,8 +188,17 @@ Vagrant.configure("2") do |config|
 
     # Shell script to set apt sources.list to something appropriate (close to you, and actually up)
     # via apt-spy2 (https://github.com/lagged/apt-spy2)
-    config.vm.provision :shell, :inline => "echo '   > > > running apt-spy2 to locate a nearby mirror (for quicker installs). Do not worry if it shows an error, it will be OK, there is a fallback.'"
-    config.vm.provision :shell, :path => "apt-spy-2-bootstrap.sh"
+
+    # If a customized version of this script exists in the config folder, use that instead
+
+    if File.exists?("config/apt-spy-2-bootstrap.sh")
+        config.vm.provision :shell, :inline => "echo '   > > > running local apt-spy2 to locate a nearby mirror (for quicker installs). Do not worry if it shows an error, it will be OK, there is a fallback.'"
+        config.vm.provision :shell, :path => "config/apt-spy-2-bootstrap.sh"
+    else
+        config.vm.provision :shell, :inline => "echo '   > > > running default apt-spy2 to locate a nearby mirror (for quicker installs). Do not worry if it shows an error, it will be OK, there is a fallback.'"
+        config.vm.provision :shell, :path => "apt-spy-2-bootstrap.sh"
+    end
+
 
     # Shell script to initialize latest Puppet on VM & also install librarian-puppet (which manages our third party puppet modules)
     # This has to be done before the puppet provisioning so that the modules are available when puppet tries to parse its manifests.

--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -53,4 +53,4 @@ fi
 
 # apt-spy2 requires running an 'apt-get update' after doing a 'fix'
 echo "Re-running apt-get update after sources updated..."
-apt-get update >/dev/null
+sudo apt-get update >/dev/null

--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -7,7 +7,7 @@
 
 # Do the initial apt-get update
 echo "Initial apt-get update..."
-apt-get update >/dev/null
+sudo apt-get update >/dev/null
 
 echo "Installing 'apt-spy2'. This tool lets us autoconfigure your 'apt' sources.list to a nearby location."
 echo "  This may take a while..."
@@ -17,12 +17,12 @@ echo "  This may take a while..."
 # * zlib1g-dev (zlib) is needed to build apt-spy2 from "native extensions" (needed to install "nokogiri" prerequisite)
 # * dnsutils ensures 'dig' is installed (to get IP address)
 # * geoip-bin ensures 'geoiplookup' is installed (lets us look up country code via IP)
-apt-get install -y ruby1.9.3 zlib1g-dev dnsutils geoip-bin >/dev/null
+sudo apt-get install -y ruby1.9.3 zlib1g-dev dnsutils geoip-bin >/dev/null
 
 # Install/Update RubyGems for the provider
 echo "Installing RubyGems..."
 if [ $DISTRIB_CODENAME != "trusty" ]; then
-  apt-get install -y rubygems >/dev/null
+  sudo apt-get install -y rubygems >/dev/null
 fi
 gem install --no-ri --no-rdoc rubygems-update
 update_rubygems >/dev/null
@@ -44,7 +44,7 @@ if [ "$(gem search -i apt-spy2)" = "false" ]; then
   gem install --no-ri --no-rdoc apt-spy2
   echo "... apt-spy2 installed!"
   echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
-  apt-spy2 fix --launchpad --commit --country=$COUNTRY
+  sudo apt-spy2 fix --launchpad --commit --country=$COUNTRY
 else
   echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
   sudo apt-spy2 check

--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -47,7 +47,8 @@ if [ "$(gem search -i apt-spy2)" = "false" ]; then
   apt-spy2 fix --launchpad --commit --country=$COUNTRY
 else
   echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
-  apt-spy2 fix --launchpad --commit --country=$COUNTRY
+  sudo apt-spy2 check
+  sudo apt-spy2 fix --launchpad --commit --country=$COUNTRY
 fi
 
 # apt-spy2 requires running an 'apt-get update' after doing a 'fix'

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -6,6 +6,9 @@
 # which is run during 'vagrant up'
 local-bootstrap.sh
 
+# Ignore any customized apt-spy-2-bootstrap.sh file
+apt-spy-2-bootstrap.sh
+
 # Ignore special 'dotfiles' folder, used to copy 
 # any local dotfiles to VM
 dotfiles

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,9 +20,9 @@
 vm_name    : 'dspace-dev'
 
 # How much memory to provide to VirtualBox VM (in MB)
-# Provide 4GB of memory by default
+# Provide 3GB of memory by default
 # (Changes to this setting require a 'vagrant reload' to take effect)
-vm_memory  : 4096
+vm_memory  : 3072
 
 # Maximum amount of host CPU which VirtualBox VM can use (in %)
 # The example below would only let VM use up to 50% of host CPU
@@ -106,12 +106,10 @@ dspace::java_version : '7'
 
 # Maven Defaults
 #
-# Always build/compile DSpace using "vagrant.properties"
-# instead of the normal "build.properties" file
 # IF you want to exclude particular webapps from building & installing, you can do so like:
-# mvn_params: '-P-dspace-lni,-dspace-rdf'
+# mvn_params: '-P-dspace-jspui,-dspace-xmlui,-dspace-rdf,'
 # (This setting is only used during a 'vagrant up')
-mvn_params        : ''
+mvn_params        : '-P-dspace-rdf'
 
 # Ant Defaults
 # NOTE: if you change 'git_branch' above, you MAY need to modify this 'ant_installer_dir'

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -105,9 +105,9 @@ dspace::java_version : '7'
 # Always build/compile DSpace using "vagrant.properties"
 # instead of the normal "build.properties" file
 # IF you want to exclude particular webapps from building & installing, you can do so like:
-# mvn_params: '-Denv=vagrant -P!dspace-lni,!dspace-rdf'
+# mvn_params: '-P-dspace-lni,-dspace-rdf'
 # (This setting is only used during a 'vagrant up')
-mvn_params        : '-Denv=vagrant'
+mvn_params        : ''
 
 # Ant Defaults
 # NOTE: if you change 'git_branch' above, you MAY need to modify this 'ant_installer_dir'

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -135,5 +135,4 @@ catalina_base     : '/var/lib/tomcat7'
 # Options to pass to Tomcat
 # This IS customizable. Feel free to tweak memory settings, etc.
 # (Changes to this setting require a 'vagrant provision' to take effect)
-catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx1024m -Xms1024m -XX:MaxPermSize=128m -XX:+UseConcMarkSweepGC'
-
+catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Dcom.sun.management.jmxremote=true -Xmx1200m -Xms1200m -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -Djava.security.egd=file:/dev/./urandom'

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,14 +20,18 @@
 vm_name    : 'dspace-dev'
 
 # How much memory to provide to VirtualBox VM (in MB)
-# Provide 2GB of memory by default
+# Provide 4GB of memory by default
 # (Changes to this setting require a 'vagrant reload' to take effect)
-vm_memory  : 2048
+vm_memory  : 4096
 
 # Maximum amount of host CPU which VirtualBox VM can use (in %)
 # The example below would only let VM use up to 50% of host CPU
 # (Changes to this setting require a 'vagrant reload' to take effect)
 #vm_max_cpu : 50
+
+# Number of CPUs to allow VirtualBox to use (2 or more help the VirtualBox VM stay responsive during
+# active development)
+vb_cpus : 1
 
 # Local IP address which will refer to this VM
 # (Changes to this setting require a 'vagrant reload' to take effect)

--- a/config/local.yaml.example
+++ b/config/local.yaml.example
@@ -37,7 +37,12 @@ vm_memory  : 2048
 # Maximum amount of host CPU which VirtualBox can use (in %)
 # The example below would only let VirtualBox use up to 50% of host CPU
 # (Changes to this setting require a 'vagrant reload' to take effect)
-#vm_max_cpu : 50
+vm_max_cpu : 50
+
+# Number of CPUs to allow VirtualBox to use (2 or more help the VirtualBox VM stay responsive during
+# active development, by default we use 1 because we can't assume you have more
+# but if you do have more than one core, you should probably set this to 2)
+vb_cpus : 1
 
 # Local IP address which will refer to this VM
 # (Changes to this setting require a 'vagrant reload' to take effect)
@@ -113,4 +118,4 @@ mvn_params        : '-Denv=vagrant -P!dspace-lni,!dspace-rdf'
 # Options to pass to Tomcat
 # This IS customizable. Feel free to tweak memory settings, etc.
 # (Changes to this setting require a 'vagrant provision' to take effect)
-catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xmx1024m -Xms1024m -XX:MaxPermSize=128m -XX:+UseConcMarkSweepGC'
+catalina_opts     : '-Djava.awt.headless=true -Dfile.encoding=UTF-8 -Dcom.sun.management.jmxremote=true -Xmx1200m -Xms1200m -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -Djava.security.egd=file:/dev/./urandom'

--- a/modules/dspace/manifests/install.pp
+++ b/modules/dspace/manifests/install.pp
@@ -108,8 +108,9 @@ define dspace::install ($owner,
 
 ->
 
-   # Create a 'vagrant.properties' file which will be used to build the DSpace installer
+   # Create a 'vagrant.properties' file which will be used by older versions of DSpace to build the DSpace installer
    # (INSTEAD OF the default 'build.properties' file that DSpace normally uses)
+   # kept for backwards compatibility, no longer needed for DSpace 6+
    file { "${src_dir}/vagrant.properties":
      ensure  => file,
      owner   => $owner,
@@ -117,6 +118,18 @@ define dspace::install ($owner,
      mode    => 0644,
      backup  => ".puppet-bak",  # If replaced, backup old settings to .puppet-bak
      content => template("dspace/vagrant.properties.erb"),
+   }
+
+->
+
+# Create a 'local.cfg' file which will be used by newer versions of DSpace (6+) to build the DSpace installer
+   file { "${src_dir}/local.cfg":
+     ensure  => file,
+     owner   => $owner,
+     group   => $group,
+     mode    => 0644,
+     backup  => ".puppet-bak",  # If replaced, backup old settings to .puppet-bak
+     content => template("dspace/local.cfg.erb"),
    }
 
 ->

--- a/modules/dspace/templates/local.cfg.erb
+++ b/modules/dspace/templates/local.cfg.erb
@@ -1,0 +1,184 @@
+# local.cfg for DSpace
+#
+# Any configurations added to this file will automatically OVERRIDE configurations
+# of the same name in any of the DSpace *.cfg files.
+#
+# While some sample configurations are provided below, you may also copy
+# ANY configuration from ANY DSpace *.cfg file into this "local.cfg" to OVERRIDE
+# its default value. This includes any of these files:
+#    * [dspace]/config/dspace.cfg
+#    * Or any configuration file that is loaded into 'dspace.cfg'
+#     (see "include =" settings near the end of dspace.cfg for full list)
+#
+# You may also specify additional configuration files to load by simply adding:
+# include = [file-path]
+# The [file-path] should be relative to the [dspace]/config/ folder, e.g.
+# include = modules/authentication-ldap.cfg
+#
+# Any commented out settings in this file are simply ignored. A configuration
+# will only override another configuration if it has the EXACT SAME key/name.
+# For example, including "dspace.dir" in this local.cfg will override the
+# default value of "dspace.dir" in the dspace.cfg file.
+#
+
+##########################
+# SERVER CONFIGURATION   #
+##########################
+
+# DSpace installation directory.
+# This is the location where you want to install DSpace.
+# Windows note: Please remember to use forward slashes for all paths (e.g. C:/dspace)
+dspace.dir=/home/vagrant/dspace
+
+# DSpace host name - should match base URL.  Do not include port number
+dspace.hostname = localhost
+
+# DSpace base host URL.  Include port number etc.
+dspace.baseUrl = http://localhost:8080
+
+# The user interface you will be using for DSpace. Common usage is either xmlui or jspui
+dspace.ui = xmlui
+
+# Full link your end users will use to access DSpace. In most cases, this will be the baseurl followed by
+# the context path to the UI you are using.
+#
+# Alternatively, you can use a url redirect or deploy the web application under the servlet container root.
+# In this case, make sure to remove the /${dspace.ui} from the dspace.url property.
+#dspace.url = ${dspace.baseUrl}/${dspace.ui}
+
+# Name of the site
+dspace.name = Vagrant DSpace
+
+# Default language for metadata values
+#default.language = en_US
+
+# Solr server/webapp.
+# DSpace uses Solr for all search/browse capability (and for usage statistics by default).
+# The included 'solr' webapp MUST be deployed to Tomcat for DSpace to function.
+# Usually it will be available via port 8080 and the 'solr' context path. But,
+# But, you may need to modify this if you are running DSpace on a custom port, etc.
+solr.server = http://localhost:8080/solr
+
+##########################
+# DATABASE CONFIGURATION #
+##########################
+# DSpace only supports two database types: PostgreSQL or Oracle
+
+# URL for connecting to database
+#    * Postgres template: jdbc:postgresql://localhost:5432/dspace
+#    * Oracle template: jdbc:oracle:thin:@//localhost:1521/xe
+db.url = jdbc:postgresql://localhost:5432/dspace
+
+# JDBC Driver
+#    * For Postgres: org.postgresql.Driver
+#    * For Oracle:   oracle.jdbc.OracleDriver
+db.driver = org.postgresql.Driver
+
+# Database Dialect (for Hibernate)
+#    * For Postgres: org.dspace.storage.rdbms.hibernate.postgres.DSpacePostgreSQL82Dialect
+#    * For Oracle:   org.hibernate.dialect.Oracle10gDialect
+db.dialect = org.dspace.storage.rdbms.hibernate.postgres.DSpacePostgreSQL82Dialect
+
+# Database username and password
+db.username = dspace
+db.password = dspace
+
+# Database Schema name
+#    * For Postgres, this is often "public" (default schema)
+#    * For Oracle, schema is equivalent to the username of your database account,
+#      so this may be set to ${db.username} in most scenarios.
+db.schema = public
+
+## Connection pool parameters
+
+# Maximum number of DB connections in pool (default = 30)
+#db.maxconnections = 30
+
+# Maximum time to wait before giving up if all connections in pool are busy (milliseconds)
+# (default = 5000ms or 5 seconds)
+#db.maxwait = 5000
+
+# Maximum number of idle connections in pool (-1 = unlimited)
+# (default = -1, unlimited)
+#db.maxidle = -1
+
+
+#######################
+# EMAIL CONFIGURATION #
+#######################
+
+# SMTP mail server (allows DSpace to send email notifications)
+#mail.server = smtp.example.com
+
+# SMTP mail server authentication username and password (if required)
+#mail.server.username = myusername
+#mail.server.password = mypassword
+
+# SMTP mail server alternate port (defaults to 25)
+#mail.server.port = 25
+
+# From address for mail
+# All mail from the DSpace site will use this 'from' address
+#mail.from.address = dspace-noreply@myu.edu
+
+# When feedback is submitted via the Feedback form, it is sent to this address
+# Currently limited to one recipient!
+#feedback.recipient = dspace-help@myu.edu
+
+# General site administration (Webmaster) e-mail
+#mail.admin = dspace-help@myu.edu
+
+# Recipient for server errors and alerts (defaults to mail.admin)
+#alert.recipient = ${mail.admin}
+
+# Recipient for new user registration emails (defaults to unspecified)
+#registration.notify =
+
+
+########################
+# HANDLE CONFIGURATION #
+########################
+
+# Canonical Handle URL prefix
+#
+# By default, DSpace is configured to use http://hdl.handle.net/
+# as the canonical URL prefix when generating dc.identifier.uri
+# during submission, and in the 'identifier' displayed in JSPUI
+# item record pages.
+#
+# If you do not subscribe to CNRI's handle service, you can change this
+# to match the persistent URL service you use, or you can force DSpace
+# to use your site's URL, eg.
+#handle.canonical.prefix = ${dspace.url}/handle/
+#
+# Note that this will not alter dc.identifer.uri metadata for existing
+# items (only for subsequent submissions), but it will alter the URL 
+# in JSPUI's 'identifier' message on item record pages for existing items.
+#
+# If omitted, the canonical URL prefix will be http://hdl.handle.net/
+#handle.canonical.prefix = http://hdl.handle.net/
+
+# CNRI Handle prefix
+# (Defaults to a dummy/fake prefix of 123456789)
+#handle.prefix = 123456789
+handle.prefix = 10673
+
+#######################
+# PROXY CONFIGURATION #
+#######################
+# uncomment and specify both properties if proxy server required
+# proxy server for external http requests - use regular hostname without port number
+#http.proxy.host =
+
+# port number of proxy server
+#http.proxy.port =
+
+#####################
+# LOGLEVEL SETTINGS #
+#####################
+loglevel.other = INFO
+# loglevel.other: Log level for other third-party tools/APIs used by DSpace
+# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL
+loglevel.dspace = INFO
+# loglevel.dspace: Log level for all DSpace-specific code (org.dspace.*)
+# Possible values (from most to least info): DEBUG, INFO, WARN, ERROR, FATAL

--- a/modules/dspace/templates/profile.erb
+++ b/modules/dspace/templates/profile.erb
@@ -29,7 +29,7 @@ export MAVEN_HOME="/usr/share/maven"
 
 # Initialize Maven Settings to build DSpace using the 'vagrant.properties' file(instead of default 'build.properties' file)
 # This ensures that you can simply run 'mvn package' from the command-line and Maven will default to using 'vagrant.properties'.
-export MAVEN_OPTS="-Denv=vagrant"
+# export MAVEN_OPTS="-Denv=vagrant" #not needed for DSpace 6+
 
 # change the prompt to include the git branch name, which is insanely helpful
 # Also change the prompt to include flags to indicate dirty state (*), stash state ($),


### PR DESCRIPTION
This work has been piling up, so I figured I'd better make this PR before it gets any bigger. Changes include:

 * ability to override the apt-spy-2-bootstrap.sh provisioner by copying the default script to your config folder, this should address the concerns raised in #39
 * add options for controlling number of CPUs and RAM available to the VM, this should address concerns raised in #40
 * added local.cfg.erb to the Puppet templates and install manifest, ensuring we get a working local.cfg file and can successfully compile the most recent version of DSpace. Leaving the old vagrant.properties file around, for backward compatibility purposes.
 * README.md file changes to reflect the above, and to drop the Landrush plugin recommendation in favor of the much simpler Vagrant-Hostsupdater plugin

Many, many thanks to @dnarc who's suggestions in #39 and #40 helped push this forward.