### PR TITLE
[DS-3260] increased librarian-puppet version to 2.2.3

### DIFF
--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -13,11 +13,11 @@ echo "Installing 'apt-spy2'. This tool lets us autoconfigure your 'apt' sources.
 echo "  This may take a while..."
 
 # Ensure dependencies are installed (These are needed to dynamically determine your country code).
-# * ruby >= 1.9.2 is needed for apt-spy2
+# * ruby >= 2.0 is needed for apt-spy2
 # * zlib1g-dev (zlib) is needed to build apt-spy2 from "native extensions" (needed to install "nokogiri" prerequisite)
 # * dnsutils ensures 'dig' is installed (to get IP address)
 # * geoip-bin ensures 'geoiplookup' is installed (lets us look up country code via IP)
-sudo apt-get install -y ruby1.9.3 zlib1g-dev dnsutils geoip-bin >/dev/null
+sudo apt-get install -y ruby2.0 zlib1g-dev dnsutils geoip-bin >/dev/null
 
 # Install/Update RubyGems for the provider
 echo "Installing RubyGems..."

--- a/puppet-bootstrap-ubuntu.sh
+++ b/puppet-bootstrap-ubuntu.sh
@@ -18,7 +18,7 @@ PUPPET_DIR=/etc/puppet/
 REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
 
 # Version of librarian-puppet to install
-LIBRARIAN_PUPPET_VERSION=2.2.1
+LIBRARIAN_PUPPET_VERSION=2.2.3
 
 #--------------------------------------------------------------------
 # NO TUNABLES BELOW THIS POINT


### PR DESCRIPTION
also switched to Ruby 2 in apt-spy-2-bootstrap, as the error with the older librarian-puppet was due to a Ruby 2 requirement, and many gems seem to be graduating to depending on Ruby 2, we might as well move on up