### PR TITLE
fallback country code was not executing properly

### DIFF
--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -36,7 +36,7 @@ export COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ pri
 
 #If country code is empty or != 2 characters, then use "US" as a default
 if [ -z "$COUNTRY" ] || [ "${#COUNTRY}" -ne "2" ]; then
-   COUNTRY = "US"
+   COUNTRY="US"
 fi
 
 if [ "$(gem search -i apt-spy2)" = "false" ]; then


### PR DESCRIPTION
With the space, bash was trying to execute "COUNTRY" with = and "US" as paremeters instead of setting COUNTRY to "US"