### PR TITLE
Removing unnecessary(?) exports

### DIFF
--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -29,10 +29,10 @@ update_rubygems >/dev/null
 
 # Figure out the two-letter country code for the current locale, based on IP address
 # First, let's get our public IP address via OpenDNS (e.g. http://unix.stackexchange.com/a/81699)
-export CURRENTIP=`dig +short myip.opendns.com @resolver1.opendns.com`
+CURRENTIP=`dig +short myip.opendns.com @resolver1.opendns.com`
 
 # Next, let's lookup our country code via IP address
-export COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ print $1}' | tr -d "[:space:]"`
+COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ print $1}' | tr -d "[:space:]"`
 
 #If country code is empty or != 2 characters, then use "US" as a default
 if [ -z "$COUNTRY" ] || [ "${#COUNTRY}" -ne "2" ]; then


### PR DESCRIPTION
The export was throwing an error because `dig +short myip.opendns.com @resolver1.opendns.com` evaluates to nothing because of the firewall rules and that line turns into 
export CURRENTIP=
Which bash doesn't like.
Are these variables used as environment variables somewhere else? If not, they should not be exported...