### PR TITLE
Bug fix. Try another apt mirror if first one fails.

### DIFF
--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -36,21 +36,31 @@ export COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ pri
 
 #If country code is empty or != 2 characters, then use "US" as a default
 if [ -z "$COUNTRY" ] || [ "${#COUNTRY}" -ne "2" ]; then
-   COUNTRY = "US"
+   COUNTRY="US"
 fi
 
 if [ "$(gem search -i apt-spy2)" = "false" ]; then
   echo "Installing apt-spy2 (and prerequisites)..."
   gem install --no-ri --no-rdoc apt-spy2
   echo "... apt-spy2 installed!"
-  echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
-  sudo apt-spy2 fix --launchpad --commit --country=$COUNTRY
-else
-  echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
-  sudo apt-spy2 check
-  sudo apt-spy2 fix --launchpad --commit --country=$COUNTRY
 fi
+
+echo "... Setting 'apt' sources.list for closest mirror to country=$COUNTRY"
+sudo apt-spy2 check
+# By default lookup a mirror using launchpad.net
+sudo apt-spy2 fix --launchpad --commit --country=$COUNTRY
 
 # apt-spy2 requires running an 'apt-get update' after doing a 'fix'
 echo "Re-running apt-get update after sources updated..."
+set +e  #temporarily ignore errors
 sudo apt-get update >/dev/null
+RESULT=$?
+set -e  # reenable exit on error
+
+# If previous apt-get errored out, re-run apt-spy2 with ubuntu list of mirrors (i.e. not launchpad)
+if [ $RESULT -ne 0 ]; then
+  echo "Initial apt-get update failed. Trying a different mirror as a fallback..."
+  sudo apt-spy2 fix --commit --country=$COUNTRY
+  echo "Re-running apt-get update after sources updated (again)..."
+  sudo apt-get update >/dev/null
+fi

--- a/apt-spy-2-bootstrap.sh
+++ b/apt-spy-2-bootstrap.sh
@@ -29,10 +29,10 @@ update_rubygems >/dev/null
 
 # Figure out the two-letter country code for the current locale, based on IP address
 # First, let's get our public IP address via OpenDNS (e.g. http://unix.stackexchange.com/a/81699)
-export CURRENTIP=`dig +short myip.opendns.com @resolver1.opendns.com`
+CURRENTIP=`dig +short myip.opendns.com @resolver1.opendns.com`
 
 # Next, let's lookup our country code via IP address
-export COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ print $1}' | tr -d "[:space:]"`
+COUNTRY=`geoiplookup $CURRENTIP | awk -F: '{ print $2 }' | awk -F, '{ print $1}' | tr -d "[:space:]"`
 
 #If country code is empty or != 2 characters, then use "US" as a default
 if [ -z "$COUNTRY" ] || [ "${#COUNTRY}" -ne "2" ]; then


### PR DESCRIPTION
Today I've run into an annoying issue with our `apt-spy-2-bootstrap.sh` script.

Essentially, the Ubuntu mirror it keeps selecting for my location claims to be "UP", but is constantly throwing a `Hash Sum mismatch` error each time `apt-get update` runs.  This means that I'm unable to successfully run a `vagrant destroy && vagrant up` as the bad mirror always kills the `vagrant up` script.

So, I took some time to put in basic error handling in the `apt-spy-2-bootstrap.sh` script.  Now, if the first mirror selected via "launchpad.net" fails, then it falls back to re-running 'apt-spy2' with default settings (which selects a mirror from mirrors.ubuntu.com). 

At least for my purposes today, this has solved my local issues of a bad (initial) mirror being selected.  Hopefully this also would help others.