### PR TITLE
adding new increase-swap.sh shell provisioner to add an 8GB swap file

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,7 +22,7 @@ vm_name    : 'dspace-dev'
 # How much memory to provide to VirtualBox VM (in MB)
 # Provide 3GB of memory by default
 # (Changes to this setting require a 'vagrant reload' to take effect)
-vm_memory  : 3072
+vm_memory  : 2048
 
 # Maximum amount of host CPU which VirtualBox VM can use (in %)
 # The example below would only let VM use up to 50% of host CPU

--- a/increase-swap.sh
+++ b/increase-swap.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# courtesy of these fine posts:
+# https://gist.github.com/shovon/9dd8d2d1a556b8bf9c82
+# http://jeqo.github.io/blog/devops/vagrant-quickstart/
+
+# size of swapfile in megabytes
+swapsize=8000
+
+# does the swap file already exist?
+grep -q "swapfile" /etc/fstab
+
+# if not then create it
+if [ $? -ne 0 ]; then
+  echo 'swapfile not found. Adding swapfile.'
+  fallocate -l ${swapsize}M /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+else
+  echo 'swapfile found. No changes made.'
+fi
+
+# output results to terminal
+df -h
+cat /proc/swaps
+cat /proc/meminfo | grep Swap


### PR DESCRIPTION
This PR adds a new shell provisioner, which adds an 8GB swap file to our vbox VM image. This should help the VM handle situations where Tomcat and Maven are competing over the same small allocation of RAM. Yes, it'll all run slower, but it will still run.
Credit goes to this gist: https://gist.github.com/shovon/9dd8d2d1a556b8bf9c82
and this article: http://jeqo.github.io/blog/devops/vagrant-quickstart/
This PR also changes the default VM memory size from 3072MB to 2048MB. In theory both should work on a host with 4GB of RAM, in practice, I'm finding one shouldn't go over 1/2 of available RAM. 