### PR TITLE
Change location to puppet-dspace (as module moved)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,5 +17,5 @@ mod "puppetlabs-postgresql", "4.8.0"
 mod "puppetlabs-tomcat", "1.5.0"
 
 # Custom Module to install DSpace
-mod "tdonohue/dspace",
-   :git => "https://github.com/tdonohue/puppet-dspace.git"
+mod "DSpace/dspace",
+   :git => "https://github.com/DSpace/puppet-dspace.git"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ How it Works
 'vagrant-dspace' does all of the following for you:
 
 * Spins up an Ubuntu 16.04 LTS virtual machine using Vagrant
-* Uses puppet-dspace module to install:
+* Uses [puppet-dspace](https://github.com/DSpace/puppet-dspace) module to install:
     * Base prerequisities for DSpace development (Java, Maven, Ant, Git)
     * PostgreSQL 9.5 (via the [puppetlabs/postgresql](http://forge.puppetlabs.com/puppetlabs/postgresql) module)
     * Tomcat 7 (via the [puppetlabs/tomcat](https://forge.puppetlabs.com/puppetlabs/tomcat))


### PR DESCRIPTION
Self explanatory. I just moved the puppet-dspace module to: https://github.com/DSpace/puppet-dspace

This PR updates vagrant-dspace to use the module in its new location
