### PR TITLE
tell librarian-puppet install to not use v1 of the puppetforge API

### DIFF
--- a/puppet-bootstrap-ubuntu.sh
+++ b/puppet-bootstrap-ubuntu.sh
@@ -100,7 +100,7 @@ if [ "$(gem search -i librarian-puppet)" = "false" ]; then
   gem install --no-ri --no-rdoc librarian-puppet --version $LIBRARIAN_PUPPET_VERSION >/dev/null
   echo "librarian-puppet installed!"
   echo "Installing third-party Puppet modules (via librarian-puppet)..."
-  cd $PUPPET_DIR && librarian-puppet install --clean
+  cd $PUPPET_DIR && librarian-puppet install --no-use-v1-api --clean
 else
   echo "Updating third-party Puppet modules (via librarian-puppet)..."
   cd $PUPPET_DIR && librarian-puppet update


### PR DESCRIPTION
 telling librarian-puppet install to not use v1 of the puppetforge API forces it to use v3 of the API, which may be the only version that puppetforge supports in the future (or possibly even right now)