### PR TITLE
Fix 'vagrant up' SSH issues for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,7 @@ Requirements
 * [Virtualization support must be enabled](http://www.howtogeek.com/213795/how-to-enable-intel-vt-x-in-your-computers-bios-or-uefi-firmware/), if you have a BIOS-based computer (aka a PC).
 * [Vagrant](http://vagrantup.com/) version 1.8.3 or above.
 * [VirtualBox](https://www.virtualbox.org/)
-* (Optional) A GitHub account with an associated SSH key. This is NOT required, but if you plan to do development on 'vagrant-dspace' and/or create Pull Requests, it is recommended. If you have a local SSH agent running, Vagrant will attempt to automatically forward your local SSH key(s) to the VM, so that you will be able to immediately interact with GitHub via SSH on the VM.
-   * WARNING: If you are on Windows, Vagrant SSH forwarding does not currently work properly. Instead we recommend creating a GitHub-specific SSH Key (at `~/.ssh/github_rsa`) which you also connect to your GitHub Account. There are a few easy ways to create this key:
-      *  Install [GitHub Desktop](http://desktop.github.com/) - this will automatically generate a new `~/.ssh/github_rsa` key.
-      * OR, manually generate a new `~/.ssh/github_rsa` key and associate it with your GitHub Account. [GitHub has detailed instructions on how to do this.](https://help.github.com/articles/generating-an-ssh-key/)
-   * SIDENOTE: Mac OSX / Linux users do NOT need this, as Vagrant's SSH Key Forwarding works properly from Mac OSX & Linux. There's just a bug in using Vagrant + Windows.
+* (Optional) A GitHub account with an associated SSH key. This is NOT required, but if you plan to do development on 'vagrant-dspace' and/or create Pull Requests, it is recommended. If you have a local SSH agent running (or [Pageant/PuTTY](http://www.putty.org/) on Windows), Vagrant will attempt to automatically forward your local SSH key(s) to the VM, so that you will be able to immediately interact with GitHub via SSH on the VM.
  * (Optional) if you are using an SSH key, we recommend that you use an RSA key. The base OS we use, Ubuntu 16.04LTS, uses OpenSSH 7.0, which [*disallows* DSA keys by default](http://viryagroup.com/what-we-do/our-blog-posts/hosting-and-linux-server-managment-blog/ssh-keys-failing-in-ubuntu-16-04-xenial-with-permission-denied-publickey). You can of course work around this, but OpenSSH made this choice for a reason, you will probably be happier in the long run if you switch to an RSA key.
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,9 @@ Vagrant.configure("2") do |config|
     # Hostname for virtual machine
     config.vm.hostname = "dspace.vagrant.dev"
 
+    # How long to wait for machine to boot (in seconds)
+    config.vm.boot_timeout = 500
+
     #-----------------------------
     # Network Settings
     #-----------------------------
@@ -143,34 +146,6 @@ Vagrant.configure("2") do |config|
     # See also https://github.com/mitchellh/vagrant/issues/1673#issuecomment-28288042
     config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
-    # THIS NEXT PART IS TOTAL HACK (only necessary for running Vagrant on Windows)
-    # Windows currently doesn't support SSH Forwarding when running Vagrant's "Provisioning scripts" 
-    # (e.g. all the "config.vm.provision" commands below). Although running "vagrant ssh" (from Windows commandline) 
-    # will work for SSH Forwarding once the VM has started up, "config.vm.provision" commands in this Vagrantfile DO NOT.
-    # Supposedly there's a bug in 'net-ssh' gem (used by Vagrant) which causes SSH forwarding to fail on Windows only
-    # See: https://github.com/mitchellh/vagrant/issues/1735
-    #      https://github.com/mitchellh/vagrant/issues/1404
-    # See also underlying 'net-ssh' bug: https://github.com/net-ssh/net-ssh/issues/55
-    #
-    # Therefore, we have to "hack it" and manually sync our SSH keys to the Vagrant VM & copy them over to the 'root' user account
-    # (as 'root' is the account that runs all Vagrant "config.vm.provision" scripts below). This all means 'root' should be able 
-    # to connect to GitHub as YOU! Once this Windows bug is fixed, we should be able to just remove these lines and everything 
-    # should work via the "config.ssh.forward_agent=true" setting.
-    # ONLY do this hack/workaround if the local OS is Windows.
-    if Vagrant::Util::Platform.windows?
-        # MORE SECURE HACK. You MUST have a ~/.ssh/github_rsa (GitHub specific) SSH key to copy to VM
-        # (ensures we are not just copying all your local SSH keys to a VM)
-        if File.exists?(File.join(Dir.home, ".ssh", "github_rsa"))
-            # Read local machine's GitHub SSH Key (~/.ssh/github_rsa)
-            github_ssh_key = File.read(File.join(Dir.home, ".ssh", "github_rsa"))
-            # Copy it to VM as the /root/.ssh/id_rsa key
-            config.vm.provision :shell, :inline => "echo 'Windows-specific: Copying local GitHub SSH Key to VM for provisioning...' && mkdir -p /root/.ssh && echo '#{github_ssh_key}' > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa", run: "always"
-        else
-            # Else, throw a Vagrant Error. Cannot successfully startup on Windows without a GitHub SSH Key!
-            raise Vagrant::Errors::VagrantError, "\n\nERROR: GitHub SSH Key not found at ~/.ssh/github_rsa (required for 'vagrant-dspace' on Windows).\nYou can generate this key manually OR by installing GitHub for Windows (http://windows.github.com/)\n\n"
-        end
-    end
-
     # Create a '/etc/sudoers.d/root_ssh_agent' file which ensures sudo keeps any SSH_AUTH_SOCK settings
     # This allows sudo commands (like "sudo ssh git@github.com") to have access to local SSH keys (via SSH Forwarding)
     # See: https://github.com/mitchellh/vagrant/issues/1303
@@ -198,8 +173,6 @@ Vagrant.configure("2") do |config|
         config.vm.provision :shell, :inline => "echo '   > > > running default increase-swap.sh scripte to ensure enough memory is available, via a swap file.'"
         config.vm.provision :shell, :path => "increase-swap.sh"
     end
-
-
 
 
     # Shell script to set apt sources.list to something appropriate (close to you, and actually up)
@@ -239,7 +212,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision :puppet do |puppet|
         puppet.manifests_path = "."
         puppet.manifest_file = "setup.pp"
-        puppet.options = "--verbose --debug"
+        puppet.options = "--verbose"
     end
 
     #-------------------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,7 +155,7 @@ Vagrant.configure("2") do |config|
     end
 
     # Check if a test SSH connection to GitHub succeeds or fails (on every vagrant up)
-    # This sets a Puppet Fact named "github_ssh_status" on the VM. 
+    # This sets a Puppet Fact named "github_ssh_status" on the VM.
     # That fact is then used by 'setup.pp' to determine whether to connect to a Git Repo via SSH or HTTPS (see setup.pp)
     config.vm.provision :shell, :inline => "echo 'Testing SSH connection to GitHub on VM...' && mkdir -p /etc/facter/facts.d/ && ssh -T -q -oStrictHostKeyChecking=no git@github.com; echo github_ssh_status=$? > /etc/facter/facts.d/github_ssh.txt", run: "always"
 
@@ -212,6 +212,8 @@ Vagrant.configure("2") do |config|
     config.vm.provision :puppet do |puppet|
         puppet.manifests_path = "."
         puppet.manifest_file = "setup.pp"
+        # NOTE: If you are hitting issues/errors with Puppet provisioning,
+        # adding "--debug" to the 'puppet.options' will provide debug logs.
         puppet.options = "--verbose"
     end
 

--- a/docs/WINDOWS_INSTRUCTIONS.md
+++ b/docs/WINDOWS_INSTRUCTIONS.md
@@ -8,15 +8,14 @@ Table of Contents
 
 1. [Step 1: Be sure your computer will allow you to run VirtualBox](#step-1-be-sure-your-computer-will-allow-you-to-run-virtualbox)
 2. [Step 2: Install Vagrant and Virtualbox](#step-2-install-vagrant-and-virtualbox)
-3. [Step 3: Set up a GitHub account](#step-3-set-up-a-github-account)
-4. [Step 4: Download and install GitHub Desktop](#step-4-download-and-install-github-desktop)
-5. [Step 5: Create an SSH key for GitHub Desktop, and configure it for your GitHub account](#step-6-create-an-ssh-key-for-github-desktop-and-configure-it-for-your-github-account)
-6. [Step 6: Fork Vagrant-DSpace and DSpace to your new GitHub account](#step-7-fork-vagrant-dspace-and-dspace-to-your-new-github-account)
-7. [Step 7: Configure a .bashrc file for Git BASH](#step-8-configure-a-bashrc-file-for-git-bash)
-8. [Step 8: Install some Vagrant plugins](#step-5-install-some-vagrant-plugins)
-9. [Step 9: Clone your fork of Vagrant-DSpace using GitHub Desktop](#step-9-clone-your-fork-of-vagrant-dspace-using-github-desktop)
-10. [Step 10: Customize your Vagrant-DSpace](#step-10-customize-your-vagrant-dspace)
-11. [Step 11: Vagrant Up! ](#step-11-vagrant-up)
+3. [Step 3: Set up a GitHub account with SSH access](#step-3-set-up-a-github-account-with-ssh-access)
+4. [Step 4: Setup PuTTY / Pageant for SSH Forwarding](#step-4-set-putty-pageant-for-ssh-forwarding)
+6. [Step 5: Fork Vagrant-DSpace and DSpace to your new GitHub account](#step-5-fork-vagrant-dspace-and-dspace-to-your-new-github-account)
+7. [Step 6: Configure a .bashrc file for Git BASH](#step-6-configure-a-bashrc-file-for-git-bash)
+8. [Step 7: Install some Vagrant plugins](#step-7-install-some-vagrant-plugins)
+9. [Step 8: Clone your fork of Vagrant-DSpace using GitHub Desktop](#step-8-clone-your-fork-of-vagrant-dspace-using-github-desktop)
+10. [Step 9: Customize your Vagrant-DSpace](#step-9-customize-your-vagrant-dspace)
+11. [Step 10: Vagrant Up! ](#step-10-vagrant-up)
 12. [Congratulations!](#congratulations)
 13. [Reporting Bugs / Requesting Enhancements](#reporting-bugs--requesting-enhancements)
 14. [License](#license)
@@ -34,31 +33,38 @@ You know the drill, this part is pretty easy: download the installer, click on t
 * [Vagrant](http://vagrantup.com/) version 1.8.3 or above.
 * [VirtualBox](https://www.virtualbox.org/)
 
-Step 3: Set up a GitHub account
+Step 3: Set up a GitHub account with SSH access
 ------------
+While this step is OPTIONAL, it is recommended if you plan to do any DSpace development (even minor bug fixes or help testing code).
+* [A GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/) After you get your GitHub account, you may wish to [explore the social features of GitHub](https://help.github.com/articles/be-social/). In particular, you should follow other developers you know or work with. This includes all developers and contributors for projects with which you work. If you ever find a project on GitHub that you think is interesting, you should star it. This will help you find it later, and also helps other people find interesting projects. Likewise, you should check out the projects other people you know have starred. You'll find amazing things.
+* Optionally install [GitHub Desktop](https://desktop.github.com/). It just makes working with GitHub easier.
+* Create an SSH key and configure it for your GitHub account (if you plan to do any development)
+    * [generate a key](https://help.github.com/articles/generating-an-ssh-key/) : GitHub Desktop will generate this key by default as part of the install process, but do verify that it exists.
+    * [add this key to your GitHub account](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/)
 
-* [A GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/)
-The README says this is optional, but it's not for these instructions. You need a GitHub account. OPTIONAL: after you get your GitHub account, you should [explore the social features of GitHub](https://help.github.com/articles/be-social/). In particular, you should follow other developers you know or work with. This includes all developers and contributors for projects with which you work. If you ever find a project on GitHub that you think is interesting, you should star it. This will help you find it later, and also helps other people find interesting projects. Likewise, you should check out the projects other people you know have starred. You'll find amazing things.
+Step 4: Setup PuTTY / Pageant for SSH Forwarding
+-------------
 
-Step 4: Download and install GitHub Desktop
-------------
+If you have GitHub SSH setup, you will WANT SSH forwarding enabled. This lets you be immediately identified with GitHub anytime you wish to add a new commit, etc.
 
-* [GitHub Deskktop](https://desktop.github.com/)
+Unfortunately, currently Vagrant has a bug where it only performs SSH Forwarding on Windows IF YOU HAVE PAGEANT running. This bug is in the net-ssh library, and supposedly is [fixed in net-ssh version 4.0.0](https://github.com/net-ssh/net-ssh/issues/192). Once Vagrant updates its dependencies, you may be able to REPLACE this step with using `ssh-agent` on Windows
 
-Step 5: Create an SSH key for GitHub in GitHub Desktop and configure it for your GitHub account
-------------
+* Install [PuTTY](http://www.putty.org/)
+  * This will install PuTTY and all its utilities to your `Program Files` under a `PuTTY` folder. Pageant (`pageant.exe`) will be included in that directory.
+* Run PuTTY Key Generator (`puttygen.exe`). You will need to generate a PuTTY version of your GitHub SSH key (as PuTTY has its own key format)
+  * Select "Conversions" -> "Import Key"
+  * Select your GitHub key (e.g. `[HOME]/.ssh/github_rsa`), and save it as a PPK file of the same name
+* Run Pageant (`pageant.exe`), and add that new PPK key to its list. Pageant may open in your notification area. [This WinSCP guide shows how to add keys to Pageant](https://winscp.net/eng/docs/ui_pageant).
+* WARNING: Pageant MUST BE RUNNING for SSH forwarding to work properly. You will likely want to set it up to startup whenever you start Windows. The WinSCP guide provides (above) provides instructions for that, or [this blog post](https://sites.google.com/a/martianpackets.com/martianpackets/Home/puttytips--runpageantonwindowsstartup).
 
-* [generate a key](https://help.github.com/articles/generating-an-ssh-key/) GitHub Desktop will generate this key by default as part of the install process, but do verify that it exists.
-* [add this key to your GitHub account](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/)
-
-Step 6: Fork Vagrant-DSpace and DSpace to your new GitHub account
+Step 5: Fork Vagrant-DSpace and DSpace to your new GitHub account
 ------------
 
 * [read how to fork a repository](https://help.github.com/articles/fork-a-repo/)
 * [fork Vagrant-DSpace](https://github.com/dspace/vagrant-dspace)
 * [fork DSpace](https://github.com/dspace/dspace)
 
-Step 7: Configure a .bashrc file for Git Bash
+Step 6: Configure a .bashrc file for Git Bash
 ------------
 
 * An example is provided in the docs folder, just copy `docs/example-bashrc` to `~/.bashrc`. It should not require tweaking, but do verify its content, _don't run it blindly_.
@@ -69,7 +75,7 @@ Step 7: Configure a .bashrc file for Git Bash
 2. Enter `cd ~ && curl https://raw.githubusercontent.com/DSpace/vagrant-dspace/master/docs/example-bashrc -o .bashrc`
 3. Verify the content of the .bashrc file that you just downloaded. Open the file with your favorite code editor, or even Windows Notepad. Git Bash comes with a version of Vim installed, you can use that if you're comfortable with Vim.
 
-Step 8: Install some Vagrant plugins
+Step 7: Install some Vagrant plugins
 ------------
 
 Since you already have a Git Bash Shell window open (from the previous step) let's just install some useful Vagrant plugins, by typing the following at your Git Bash Shell command line prompt:
@@ -80,16 +86,16 @@ vagrant plugin install vagrant-cachier
 vagrant plugin install vagrant-vbguest
 vagrant plugin install vagrant-vbox-snapshot
 ```
-It's OK to exit this Git Bash Sehll window, after you are done installing Vagrant Plugins, by entering `exit` at your Git Bash Shell command line prompt. 
+It's OK to exit this Git Bash Sehll window, after you are done installing Vagrant Plugins, by entering `exit` at your Git Bash Shell command line prompt.
 
-Step 9: Clone your fork of Vagrant-DSpace using GitHub Deskktop
+Step 8: Clone your fork of Vagrant-DSpace using GitHub Deskktop
 ------------
 
 1. If it's not already running, start GitHub Desktop by double-clicking the GitHub shortcut icon on your desktop, or launch GitHub from the Start menu.
 2. Click the plus/+ icon in the top left menu
 3. Select "Clone", enter the Git URL for your fork of Vagrant-DSpace (created in Step 7 above). This URL will look something like: `git@github.com:yourgithubusername/vagrant-dspace.git`. An easy way to find this URL is to navigate to your fork on the GitHub site: `https://github.com/yourgithubusername/vagrant-dspace` and then click the green "Clone or download" button, using the Clone with SSH option.  
 
-Step 10: customize your Vagrant-DSpace
+Step 9: Customize your Vagrant-DSpace
 ------------
 
 1. in the `config` folder of Vagrant-DSpace, copy the `local.yaml.example` file to `local.yaml`, and then open the `local.yaml` file in your favorite code editor.
@@ -100,7 +106,7 @@ Step 10: customize your Vagrant-DSpace
 
 For a more complete description of the local.yaml file, and all the other configuration options available to you, consult the [How to Tweak Things to your Liking](https://github.com/DSpace/vagrant-dspace/blob/master/README.md#how-to-tweak-things-to-your-liking) section of the README.
 
-Step 11: Vagrant Up!
+Step 10: Vagrant Up!
 ------------
 
 1. If it's not already running, start GitHub Desktop by double-clicking the GitHub shortcut icon on your desktop, or launch GitHub from the Start menu.


### PR DESCRIPTION
The current master branch won't work properly on Windows because of SSH forwarding issues.

This PR fixes the problems by documenting a new REQUIREMENT to install/config PuTTY/Pageant to support SSH Forwarding on Windows. 

The old SSH key hack (to copy it to the VM) in our `Vagrantfile` was removed, as it doesn't work properly for our Puppet setup scripts (which run as the `vagrant` user).

Once Vagrant updates to net-ssh 4.0.0, this requirement for PuTTY/Pageant should be removed, per this ticket: https://github.com/net-ssh/net-ssh/issues/192

To test this PR:
* Pull down the branch to a Windows machine
* Install PuTTY/Pageant (per new instructions)
* Run a full `vagrant destroy` followed by a `vagrant up`. If it works, then this PR is successful.